### PR TITLE
refactor(whole project): change publishing mechanism

### DIFF
--- a/src/api/history/history.js
+++ b/src/api/history/history.js
@@ -1,4 +1,4 @@
-import { publish, addMiddlewares } from 'pubsub';
+import { addMiddlewares } from 'pubsub';
 
 import { collectState } from 'api/utils';
 
@@ -24,14 +24,14 @@ const createHistory = (models, { captureExisting } = {}) => {
     goBack: () => {
       if (pointer > 1) {
         const { index, next } = findDiff(history[pointer - 1], history[pointer - 2]);
-        publish(models[index].event, next, historyOptions);
+        models[index].publish(next, historyOptions);
         pointer--;
       }
     },
     goForward: () => {
       if (pointer < history.length) {
         const { index, previous } = findDiff(history[pointer], history[pointer - 1]);
-        publish(models[index].event, previous, historyOptions);
+        models[index].publish(previous, historyOptions);
         pointer++;
       }
     },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,3 +1,3 @@
 export { createStore } from './store';
 export { createHistory } from './history';
-export { createModel, createVirtualModel, publishModel } from './configure';
+export { createModel, createVirtualModel } from './configure';

--- a/src/api/store/store.js
+++ b/src/api/store/store.js
@@ -1,4 +1,4 @@
-import { createModel, createVirtualModel } from 'api/configure';
+import { createModel, createVirtualModel, publishModel } from 'api/configure';
 
 import { createProxy } from './utils';
 
@@ -49,6 +49,11 @@ function createStore(options) {
       return () => {
         subscribers = subscribers.filter(subscriber => subscriber !== callback);
       }
+    },
+    publish: (segments, options) => {
+      Object.entries(segments).forEach(([key, value]) => {
+        result[key].publish(value, options);
+      });
     },
   };
 };

--- a/src/api/store/store.js
+++ b/src/api/store/store.js
@@ -1,4 +1,4 @@
-import { createModel, createVirtualModel, publishModel } from 'api/configure';
+import { createModel, createVirtualModel } from 'api/configure';
 
 import { createProxy } from './utils';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 export {
   createStore,
   createModel,
-  publishModel,
   createHistory,
   createVirtualModel,
 } from 'api';

--- a/src/pubsub/events.js
+++ b/src/pubsub/events.js
@@ -2,7 +2,6 @@ import { createDefault } from 'utils';
 
 import { needLogs } from './utils';
 
-// https://stackoverflow.com/questions/18541940/map-vs-object-in-javascript/43305977
 const events = {};
 
 const doesEventExist = event => !!events[event];

--- a/src/pubsub/middlewares.js
+++ b/src/pubsub/middlewares.js
@@ -1,8 +1,6 @@
 const middlewares = [];
 
-const addMiddlewares = (...args) => {
-  middlewares.push(...args);
-}
+const addMiddlewares = (...args) => middlewares.push(...args);
 
 const runMiddlewares = (previous, next, options, callbacks) => {
   if (callbacks.length) {

--- a/src/pubsub/pubsub.js
+++ b/src/pubsub/pubsub.js
@@ -7,6 +7,8 @@ import { applyMiddlewares } from './middlewares';
 const publish = async (event, valueSetter, options) => {
   const neededEvent = getEvent(event);
 
+  if (!neededEvent) return log(`No event named ${event}`);
+
   if (neededEvent.options.fireDuplicates || !isEqual(valueSetter, neededEvent.lastState)) {
 
     const isFunction = typeof valueSetter === 'function';

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,4 +3,6 @@ const isEqual = (next, prev) => Object.is(next, prev);
 
 const createDefault = (lastState, options = {}) => ({ lastState, options, subscribers: [] });
 
-export { isEqual, createDefault };
+const noop = () => {};
+
+export { isEqual, createDefault, noop };

--- a/tests/api/addMiddlewares.test.js
+++ b/tests/api/addMiddlewares.test.js
@@ -1,4 +1,4 @@
-import { addMiddlewares, createModel, publishModel } from 'src';
+import { addMiddlewares, createModel } from 'src';
 
 describe('Adding a middleware', () => {
   test('middleware must be fired on model change', () => {
@@ -6,19 +6,19 @@ describe('Adding a middleware', () => {
     const example = createModel('start');
 
     addMiddlewares(middleware);
-    publishModel(example, 'final');
+    example.publish('final');
 
     expect(middleware).toBeCalledTimes(1);
   });
 
 
-  test('middleware must be fired on model change', () => {
+  test('middlewares must be fired on model change', () => {
     const middleware1 = jest.fn();
     const middleware2 = jest.fn();
     const example = createModel('start');
 
     addMiddlewares(middleware1, middleware2);
-    publishModel(example, 'final');
+    example.publish('final');
 
     expect(middleware1).toBeCalledTimes(1);
     expect(middleware2).toBeCalledTimes(1);
@@ -33,7 +33,7 @@ describe('Adding a middleware', () => {
 
     example.subscribe(callback);
     addMiddlewares(middleware);
-    publishModel(example, 'final');
+    example.publish('final');
     expect(middleware).toBeCalledTimes(1);
   });
 
@@ -45,7 +45,7 @@ describe('Adding a middleware', () => {
     const example = createModel(initialValue);
 
     addMiddlewares(middleware);
-    publishModel(example, finalValue);
+    example.publish(finalValue);
 
     expect(middleware).lastCalledWith(initialValue, finalValue, { model: example });
   });

--- a/tests/api/createHistory.test.js
+++ b/tests/api/createHistory.test.js
@@ -1,4 +1,4 @@
-import { createHistory, createModel, publishModel } from 'src';
+import { createHistory, createModel } from 'src';
 
 describe('Create history for models', () => {
   test('history object must match the pattern', () => {
@@ -19,7 +19,7 @@ describe('Create history for models', () => {
     expect(history.hasPrevious()).toBe(false);
     expect(history.hasNext()).toBe(false);
 
-    publishModel(grossSalary, 200_000);
+    grossSalary.publish(200_000);
 
     expect(history.hasPrevious()).toBe(true);
     expect(history.hasNext()).toBe(false);
@@ -33,7 +33,7 @@ describe('Create history for models', () => {
     expect(history.hasPrevious()).toBe(false);
     expect(history.hasNext()).toBe(false);
 
-    publishModel(taxes, 40);
+    taxes.publish(40);
 
     expect(history.hasPrevious()).toBe(false);
     expect(history.hasNext()).toBe(false);
@@ -46,8 +46,8 @@ describe('Create history for models', () => {
     const taxes = createModel(20);
     const history = createHistory([grossSalary, taxes]);
 
-    publishModel(taxes, 40);
-    publishModel(grossSalary, finalStateGrossSalary);
+    taxes.publish(40);
+    grossSalary.publish(finalStateGrossSalary);
     test('go back', () => {
       history.goBack();
       expect(grossSalary.getState()).toBe(initialGrossSalary);
@@ -65,14 +65,14 @@ describe('Create history for models', () => {
     const taxes = createModel(20);
     const history = createHistory([grossSalary, taxes]);
 
-    publishModel(taxes, 40);
-    publishModel(grossSalary, finalStateGrossSalary);
+    taxes.publish(40);
+    grossSalary.publish(finalStateGrossSalary);
     history.goBack();
     history.goBack();
 
     expect(history.hasNext()).toBe(true);
 
-    publishModel(taxes, 40);
+    taxes.publish(40);
 
     expect(history.hasNext()).toBe(false);
   });

--- a/tests/api/createModel.test.js
+++ b/tests/api/createModel.test.js
@@ -1,4 +1,4 @@
-import { createModel, publishModel } from 'src';
+import { createModel } from 'src';
 
 describe('Creating a Model', () => {
   test('model object matches pattern', () => {
@@ -22,7 +22,7 @@ describe('Creating a Model', () => {
 
     expect(model.getState()).toBe(initialValue);
 
-    publishModel(model, nextValue);
+    model.publish(nextValue);
 
     expect(model.getState()).toBe(nextValue);
   });
@@ -34,7 +34,7 @@ describe('Creating a Model', () => {
 
     expect(model.getState()).toBe(initialValue);
 
-    publishModel(model, () => nextValue);
+    model.publish(() => nextValue);
 
     expect(model.getState()).toBe(nextValue);
   });
@@ -45,7 +45,7 @@ describe('Creating a Model', () => {
     const callback = jest.fn();
 
     model.subscribe(callback);
-    publishModel(model, nextValue);
+    model.publish(nextValue);
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith(nextValue);
@@ -57,7 +57,7 @@ describe('Creating a Model', () => {
     const callback = jest.fn();
 
     model.subscribe(callback);
-    publishModel(model, initialValue);
+    model.publish(initialValue);
 
     expect(callback).toBeCalledTimes(0);
   });
@@ -68,7 +68,7 @@ describe('Creating a Model', () => {
     const callback = jest.fn();
 
     model.subscribe(callback);
-    publishModel(model, initialValue);
+    model.publish(initialValue);
 
     expect(callback).toBeCalledTimes(1);
   });

--- a/tests/api/createStore.test.js
+++ b/tests/api/createStore.test.js
@@ -1,4 +1,4 @@
-import { createStore, publishModel } from 'src';
+import { createStore } from 'src';
 
 describe('Creating a store', () => {
   test('store object matches pattern', () => {
@@ -8,6 +8,7 @@ describe('Creating a store', () => {
     });
 
     expect(typeof store.models).toBe('object');
+    expect(typeof store.publish).toBe('function');
     expect(typeof store.getState).toBe('function');
     expect(typeof store.subscribe).toBe('function');
   });
@@ -21,7 +22,7 @@ describe('Creating a store', () => {
 
     expect(store.getState()).toEqual(initialState);
 
-    publishModel(store.models.name, 'Jain');
+    store.models.name.publish('Jain');
 
     expect(store.getState()).toEqual({
       name: 'Jain',
@@ -38,7 +39,7 @@ describe('Creating a store', () => {
     const callback = jest.fn();
 
     store.subscribe(callback);
-    publishModel(store.models.name, 'Jain');
+    store.models.name.publish('Jain');
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith('name', 'Jain', store.models.name);
@@ -65,7 +66,7 @@ describe('Creating a store', () => {
       netSalary: ({ taxes, grossSalary }) => grossSalary * (100 - taxes) / 100,
     });
 
-    publishModel(store.models.taxes, 30);
+    store.models.taxes.publish(30);
 
     expect(store.getState()).toEqual({
       taxes: 30,
@@ -82,7 +83,7 @@ describe('Creating a store', () => {
       isEnough: ({ netSalary }) => netSalary > 100_000,
     });
 
-    publishModel(store.models.taxes, 30);
+    store.models.taxes.publish(30);
 
     expect(store.getState()).toEqual({
       taxes: 30,
@@ -91,7 +92,7 @@ describe('Creating a store', () => {
       isEnough: false
     });
 
-    publishModel(store.models.grossSalary, 200_000);
+    store.models.grossSalary.publish(200_000);
 
     expect(store.getState()).toEqual({
       taxes: 30,
@@ -99,5 +100,38 @@ describe('Creating a store', () => {
       grossSalary: 200_000,
       isEnough: true
     });
+  });
+
+  test('publish method must update the store by single value', () => {
+    const initialState = {
+      name: 'John',
+      surname: 'Doe',
+    };
+    const fragment = {
+      name: 'Jane',
+    }
+
+    const store = createStore(initialState);
+    store.publish(fragment);
+
+    expect(store.getState()).toEqual({ ...initialState, ...fragment });
+  });
+
+
+  test('publish method must update the store by multiple values', () => {
+    const initialState = {
+      age: 21,
+      name: 'John',
+      surname: 'Doe',
+    };
+    const fragment = {
+      name: 'Jane',
+      age: 35,
+    }
+
+    const store = createStore(initialState);
+    store.publish(fragment);
+
+    expect(store.getState()).toEqual({ ...initialState, ...fragment });
   });
 });

--- a/tests/api/createVirtualModel.test.js
+++ b/tests/api/createVirtualModel.test.js
@@ -1,4 +1,4 @@
-import { createModel, publishModel, createVirtualModel } from 'src';
+import { createModel, createVirtualModel } from 'src';
 
 describe('Creating a Virtual Model', () => {
   test('model object pass match pattern', () => {
@@ -37,7 +37,7 @@ describe('Creating a Virtual Model', () => {
 
     expect(netSalary.getState()).toBe(80_000);
 
-    publishModel(grossSalary, 200_000);
+    grossSalary.publish(200_000);
 
     expect(netSalary.getState()).toBe(160_000);
   });
@@ -52,7 +52,7 @@ describe('Creating a Virtual Model', () => {
 
     expect(netSalary.getState()).toBe(80_000);
 
-    publishModel(taxes, () => 40);
+    taxes.publish(() => 40);
 
     expect(netSalary.getState()).toBe(60_000);
   });
@@ -73,12 +73,12 @@ describe('Creating a Virtual Model', () => {
     const nextValue3 = { city: 'Tokio' };
 
     virtual.subscribe(callback);
-    publishModel(model2, nextValue2);
+    model2.publish(nextValue2);
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith(`${value1} is alone in ${value3.city} at his ${nextValue2}`);
 
-    publishModel(model3, nextValue3);
+    model3.publish(nextValue3);
 
     expect(callback).toBeCalledTimes(2);
     expect(callback).lastCalledWith(`${value1} is alone in ${nextValue3.city} at his ${nextValue2}`);
@@ -99,12 +99,12 @@ describe('Creating a Virtual Model', () => {
     const callback = jest.fn();
 
     netSalaryInEuros.subscribe(callback);
-    publishModel(taxes, 40);
+    taxes.publish(40);
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith(48_000);
 
-    publishModel(euroRate, 0.5);
+    euroRate.publish(0.5);
 
     expect(callback).toBeCalledTimes(2);
     expect(callback).lastCalledWith(30_000);
@@ -120,7 +120,7 @@ describe('Creating a Virtual Model', () => {
     expect(netSalary.getState()).toBe(80_000);
 
     netSalary.setOptions({ models: [grossSalary] });
-    publishModel(grossSalary, 200_000);
+    grossSalary.publish(200_000);
 
     expect(netSalary.getState()).toBe(160_000);
   });
@@ -135,11 +135,11 @@ describe('Creating a Virtual Model', () => {
     expect(netSalary.getState()).toBe(80_000);
 
     netSalary.setOptions({ models: [grossSalary] });
-    publishModel(grossSalary, 200_000);
+    grossSalary.publish(200_000);
 
     expect(netSalary.getState()).toBe(160_000);
 
-    publishModel(taxes, 50);
+    taxes.publish(50);
 
     expect(netSalary.getState()).toBe(160_000);
   });

--- a/tests/api/publishModel.test.js
+++ b/tests/api/publishModel.test.js
@@ -1,4 +1,4 @@
-import { publishModel, createModel } from 'src';
+import { createModel } from 'src';
 
 describe('Publishing a Model', () => {
 
@@ -11,7 +11,7 @@ describe('Publishing a Model', () => {
     expect(model.getState()).toBe(initalValue);
 
     model.subscribe(callback);
-    publishModel(model, nextValue);
+    model.publish(nextValue);
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith(nextValue);
@@ -29,7 +29,7 @@ describe('Publishing a Model', () => {
     expect(model.getState()).toBe(initalValue);
 
     model.subscribe(callback);
-    publishModel(model, publisher);
+    model.publish(publisher);
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith(nextValue);
@@ -44,7 +44,7 @@ describe('Publishing a Model', () => {
     const model = createModel(initialValue);
     const callback = jest.fn();
 
-    publishModel(model, callback);
+    model.publish(callback);
 
     expect(callback).toBeCalledTimes(1);
     expect(callback).lastCalledWith(initialValue);
@@ -59,7 +59,7 @@ describe('Publishing a Model', () => {
       return new Promise(resolve => setTimeout(() => resolve(finalValue), waitTime));
     }
 
-    publishModel(model, callback);
+    model.publish(callback);
     await callback();
 
     expect(model.getState()).toBe(finalValue);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,9 @@
+type AnyObject = { [key: string]: any };
+
 export interface IModel<T> {
   getState: () => T;
   event: string | string[];
+  publish: (value: T, options: AnyObject) => void;
   subscribe: (callback: () => void, needPrevious?: boolean) => () => void;
 }
 
@@ -13,7 +16,6 @@ export interface IModelsHistory {
 
 export function createModel<T>(value: T): IModel<T>;
 export function createVirtualModel<T>(callback: () => T, options?: { models?: IModel<any>[] }) => IModel<T>;
-export function publishModel<T>(model: IModel<T>, value: T | ((nextValue: T) => T)): void;
 
 export function addMiddlewares(
   ...middlewares: Array<(previousValue: any, nextValue: any, options: { model: IModel<any> }) => void>
@@ -21,8 +23,9 @@ export function addMiddlewares(
 
 export function createHistory(models: IModel<any>[], options?: { captureExisting: boolean }): IModelsHistory;
 
-export function createStore(options: { [key: string]: any} ): {
+export function createStore(options: AnyObject ): {
   getState: () => object;
   subscribe: ((key: string, value: any, model: IModel<any>) => void) => void;
   model: { [key: string]: IModel<any> };
+  publish: (segments: AnyObject, options: AnyObject) => void;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ type AnyObject = { [key: string]: any };
 export interface IModel<T> {
   getState: () => T;
   event: string | string[];
-  publish: (value: T, options: AnyObject) => void;
+  publish: (value: T, options?: AnyObject) => void;
   subscribe: (callback: () => void, needPrevious?: boolean) => () => void;
 }
 
@@ -27,5 +27,5 @@ export function createStore(options: AnyObject ): {
   getState: () => object;
   subscribe: ((key: string, value: any, model: IModel<any>) => void) => void;
   model: { [key: string]: IModel<any> };
-  publish: (segments: AnyObject, options: AnyObject) => void;
+  publish: (segments: AnyObject, options?: AnyObject) => void;
 };


### PR DESCRIPTION
Considering API consistency and laconism, it is better to have "publish" and "subscribe" methods
both available on the model itself. Previously the "ubscribe" was on the model, "publish" was
separate method